### PR TITLE
[Keplr] - Replace the download source for Keplr wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tobelabs/chainwright
 
+## 0.10.12
+
+### Patch Changes
+
+- [Keplr] - Replacing the download source because the maintainers of the Keplr wallet have made their repository private; we can no longer download the zip file directly from it.
+
 ## 0.10.11
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chainwright",
-    "version": "0.10.11",
+    "version": "0.10.12",
     "description": "Playwright Web3 wallet testing framework for end-to-end dApp automation with MetaMask, Phantom, Solflare, Petra, Meteor, and Keplr",
     "type": "module",
     "license": "MIT",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,10 +5,8 @@ export const WALLET_CONTEXT_DIR_NAME = ".wallet-context";
 export const WALLET_SETUP_DIR_NAME = "wallet-setup";
 
 const METAMASK_VERSION = "13.33.0";
-const KEPLR_VERSION = "0.13.39";
 
 const ARCHIVED_WALLET_BASE_URL = `https://github.com/amaify/chainwright/releases/download/v0.1.0/`;
-const KEPLR_WALLET_BASE_URL = `https://github.com/chainapsis/keplr-wallet/releases/download/v${KEPLR_VERSION}/`;
 const METAMASK_WALLET_BASE_URL = `https://github.com/MetaMask/metamask-extension/releases/download/v${METAMASK_VERSION}/`;
 
 export const METAMASK_DOWNLOAD_URL = `${METAMASK_WALLET_BASE_URL}metamask-chrome-${METAMASK_VERSION}.zip`;
@@ -16,7 +14,7 @@ export const SOLFLARE_DOWNLOAD_URL = `${ARCHIVED_WALLET_BASE_URL}solflare-wallet
 export const PETRA_DOWNLOAD_URL = `${ARCHIVED_WALLET_BASE_URL}petra-wallet-extension-v2.4.8.zip`;
 export const PHANTOM_DOWNLOAD_URL = `${ARCHIVED_WALLET_BASE_URL}phantom-wallet-extension-v26.10.0.zip`;
 export const METEOR_DOWNLOAD_URL = `${ARCHIVED_WALLET_BASE_URL}meteor-wallet-extension-v0.7.0.zip`;
-export const KEPLR_DOWNLOAD_URL = `${KEPLR_WALLET_BASE_URL}keplr-extension-manifest-v3-v${KEPLR_VERSION}.zip`;
+export const KEPLR_DOWNLOAD_URL = `${ARCHIVED_WALLET_BASE_URL}keplr-wallet-extension-v0.13.39.zip`;
 
 export const SUPPORTED_WALLETS: SupportedWalletsMap = {
     metamask: {
@@ -47,6 +45,6 @@ export const SUPPORTED_WALLETS: SupportedWalletsMap = {
     keplr: {
         downloadUrl: KEPLR_DOWNLOAD_URL,
         extensionName: "Keplr",
-        sha256: "15811192edf86074e351c4e4e569ec1282054f316f6d958fa6c5485e23aa47b6",
+        sha256: "12182982784ac20c6741eaad036f4529d49dc4c222b0e6118e8647606e5a296f",
     },
 };


### PR DESCRIPTION
Replacing the download source because the maintainers of the Keplr wallet have made their repository private; we can no longer download the zip file directly from it.